### PR TITLE
Fix leaflet 403 error by changing default street basemap to OpenTopoMap

### DIFF
--- a/R/camtrapDensity.R
+++ b/R/camtrapDensity.R
@@ -335,9 +335,11 @@ recalc_events <- function(pkg){
 map_deployments <- function(pkg, basemap=c("street", "satellite"), ...){
   basemap <- match.arg(basemap)
   map <- leaflet::leaflet(data = pkg$data$deployments)
-  map <- if(basemap == "street")
-    leaflet::addTiles(map) else
-      leaflet::addProviderTiles(map,"Esri.WorldImagery")
+  map <- if(basemap == "street") {
+    leaflet::addProviderTiles(map, "OpenTopoMap") 
+  } else {
+    leaflet::addProviderTiles(map, "Esri.WorldImagery")
+  }
   leaflet::addCircleMarkers(map, lng = ~longitude, lat = ~latitude,
                             popup = ~locationName, ...)
 }
@@ -386,9 +388,11 @@ map_traprates <- function(pkg, species=NULL, basemap=c("street", "satellite"),
                  "; border-radius:50%")
 
   map <- leaflet::leaflet(data = trdat)
-  map <- if(basemap == "street")
-    leaflet::addTiles(map) else
-      leaflet::addProviderTiles(map,"Esri.WorldImagery")
+  map <- if(basemap == "street") {
+    leaflet::addProviderTiles(map, "OpenTopoMap") 
+  } else {
+    leaflet::addProviderTiles(map, "Esri.WorldImagery")
+  }
   leaflet::addCircleMarkers(map, lng = ~longitude, lat = ~latitude,
                             popup = ~paste0(locationName, ": ",
                                             round(tr, 2-floor(log10(tr))),


### PR DESCRIPTION
Dear Marcus,

This Pull Request fixes the persistent Leaflet 403 Forbidden error that occurs when loading maps, created by map_traprates function in local browser sessions. 

OpenStreetMap's updated security policy blocks requests that lack a standard referrer string. Replacing the default `leaflet::addTiles()` with `leaflet::addProviderTiles(map, "OpenTopoMap")` completely bypasses the block and provides a beautiful topographic terrain basemap well-suited for camera trap fieldwork.

If you accept this fix you can update it for everyone.

Kind regards,
Stoyan
